### PR TITLE
feat: add command probe

### DIFF
--- a/.aqua/aqua-checksums.json
+++ b/.aqua/aqua-checksums.json
@@ -1,109 +1,109 @@
 {
-  "checksums": [
-    {
-      "id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_darwin_all.tar.gz",
-      "checksum": "E5664B4DE41C6696358BD456F5283E86F0BD30E65AB65FAAD349293D804F088E",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_linux_amd64.tar.gz",
-      "checksum": "89A0BD658256C8561272EF2927EC0240C860779B042598C0456864583C88F702",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_linux_arm64.tar.gz",
-      "checksum": "59B973E51E65BB153B97A1D4CA1E46347136EEDC0DA60594F6BB5B87C8B1AD45",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_windows_amd64.zip",
-      "checksum": "74D8F24C312F2FFBD0866A2D38780B076A3D5EDF6690FBB17783358E3E88AFB4",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_windows_arm64.zip",
-      "checksum": "2622A9322D6786363E746F6A5CA4884F858C59289571D567B46C18D2C2E160ED",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-aarch64-apple-darwin.tar.gz",
-      "checksum": "BB0D35F6CA04709B798A19217693C16F4086170C580CC3B5C2531AD2794D2E32",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-aarch64-unknown-linux-musl.tar.gz",
-      "checksum": "4FCD8310081C32742EB984B1FDD0EEE2E5D4D0F1BE9629318012D42606EC9B3E",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-x86_64-apple-darwin.tar.gz",
-      "checksum": "687F66A6BD4D7D946EF5FF1E3EFEBB3D39DADAD151A8C6B1DE884CC93ADC06A5",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-x86_64-pc-windows-msvc.zip",
-      "checksum": "04BE7B6D7F8419288CE75532F1962CEE1756992E494E6C8063BB3AB8DB21B52C",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-x86_64-unknown-linux-musl.tar.gz",
-      "checksum": "A1BC93654F31669FD964EA3011A5E5E9676B9B6F8ADCD762606E5140632EA72D",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Darwin_all.tar.gz",
-      "checksum": "7AF0CE76660556F8A7CEB6C3D1B438E170EE3F551D5408153830697EB25F5962",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Linux_arm64.tar.gz",
-      "checksum": "A841DB4911C1DC32FB8EB1D4AFE91AE218C71BBC3B18379F9CDDB2EE899ACA31",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Linux_x86_64.tar.gz",
-      "checksum": "FD64C4BAEA57043A63CC209E8AD3FA54A7E3EDA88BF0D053D1AF9B577F328EAC",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Windows_arm64.zip",
-      "checksum": "D2FF86ED139485397DE82274628D6C1F725AD33614F81F043C798FDA46030D23",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Windows_x86_64.zip",
-      "checksum": "2D7E94D17806ED2EB704870716E66218AC8D062BFDB7DC105E575564AA54ADFE",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-darwin-aarch64.zip",
-      "checksum": "EB8C7E09CBEA572414A0A367848E1ACBF05294A946A594405A014B1FB3B3FC76",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-darwin-x64.zip",
-      "checksum": "A7484721A7EAD45887C812E760B124047E663173CF2A3BA7C5AA1992CB22CD3E",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-linux-aarch64.zip",
-      "checksum": "A97C687FB5E54DE4E2FB0869A7AC9A2D9C3AF75AC182E2B68138C1DD8F98131B",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-linux-x64.zip",
-      "checksum": "4C446AF1A01D7B40E1E11BAEBC352F9B2BFD12887E51B97DD3B59879CEE2743A",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-windows-x64.zip",
-      "checksum": "3A28C685B47A159C5707D150ACCB5B4903C30F1E7B4DD01BB311D4112BDEB452",
-      "algorithm": "sha256"
-    },
-    {
-      "id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.418.0/registry.yaml",
-      "checksum": "A388A9445DBB89721022D840C42A73106650FB0536C4ED6F0C38537C7AC32701",
-      "algorithm": "sha256"
-    }
-  ]
+	"checksums": [
+		{
+			"id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_darwin_all.tar.gz",
+			"checksum": "E5664B4DE41C6696358BD456F5283E86F0BD30E65AB65FAAD349293D804F088E",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_linux_amd64.tar.gz",
+			"checksum": "89A0BD658256C8561272EF2927EC0240C860779B042598C0456864583C88F702",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_linux_arm64.tar.gz",
+			"checksum": "59B973E51E65BB153B97A1D4CA1E46347136EEDC0DA60594F6BB5B87C8B1AD45",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_windows_amd64.zip",
+			"checksum": "74D8F24C312F2FFBD0866A2D38780B076A3D5EDF6690FBB17783358E3E88AFB4",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/caarlos0/svu/v3.2.4/svu_3.2.4_windows_arm64.zip",
+			"checksum": "2622A9322D6786363E746F6A5CA4884F858C59289571D567B46C18D2C2E160ED",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-aarch64-apple-darwin.tar.gz",
+			"checksum": "BB0D35F6CA04709B798A19217693C16F4086170C580CC3B5C2531AD2794D2E32",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-aarch64-unknown-linux-musl.tar.gz",
+			"checksum": "4FCD8310081C32742EB984B1FDD0EEE2E5D4D0F1BE9629318012D42606EC9B3E",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-x86_64-apple-darwin.tar.gz",
+			"checksum": "687F66A6BD4D7D946EF5FF1E3EFEBB3D39DADAD151A8C6B1DE884CC93ADC06A5",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-x86_64-pc-windows-msvc.zip",
+			"checksum": "04BE7B6D7F8419288CE75532F1962CEE1756992E494E6C8063BB3AB8DB21B52C",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/casey/just/1.43.0/just-1.43.0-x86_64-unknown-linux-musl.tar.gz",
+			"checksum": "A1BC93654F31669FD964EA3011A5E5E9676B9B6F8ADCD762606E5140632EA72D",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Darwin_all.tar.gz",
+			"checksum": "7AF0CE76660556F8A7CEB6C3D1B438E170EE3F551D5408153830697EB25F5962",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Linux_arm64.tar.gz",
+			"checksum": "A841DB4911C1DC32FB8EB1D4AFE91AE218C71BBC3B18379F9CDDB2EE899ACA31",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Linux_x86_64.tar.gz",
+			"checksum": "FD64C4BAEA57043A63CC209E8AD3FA54A7E3EDA88BF0D053D1AF9B577F328EAC",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Windows_arm64.zip",
+			"checksum": "D2FF86ED139485397DE82274628D6C1F725AD33614F81F043C798FDA46030D23",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/goreleaser/goreleaser/v2.12.3/goreleaser_Windows_x86_64.zip",
+			"checksum": "2D7E94D17806ED2EB704870716E66218AC8D062BFDB7DC105E575564AA54ADFE",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-darwin-aarch64.zip",
+			"checksum": "EB8C7E09CBEA572414A0A367848E1ACBF05294A946A594405A014B1FB3B3FC76",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-darwin-x64.zip",
+			"checksum": "A7484721A7EAD45887C812E760B124047E663173CF2A3BA7C5AA1992CB22CD3E",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-linux-aarch64.zip",
+			"checksum": "A97C687FB5E54DE4E2FB0869A7AC9A2D9C3AF75AC182E2B68138C1DD8F98131B",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-linux-x64.zip",
+			"checksum": "4C446AF1A01D7B40E1E11BAEBC352F9B2BFD12887E51B97DD3B59879CEE2743A",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "github_release/github.com/oven-sh/bun/bun-v1.2.22/bun-windows-x64.zip",
+			"checksum": "3A28C685B47A159C5707D150ACCB5B4903C30F1E7B4DD01BB311D4112BDEB452",
+			"algorithm": "sha256"
+		},
+		{
+			"id": "registries/github_content/github.com/aquaproj/aqua-registry/v4.418.0/registry.yaml",
+			"checksum": "A388A9445DBB89721022D840C42A73106650FB0536C4ED6F0C38537C7AC32701",
+			"algorithm": "sha256"
+		}
+	]
 }

--- a/examples/exec-probe/api.ts
+++ b/examples/exec-probe/api.ts
@@ -3,22 +3,25 @@
 import { serve } from "bun";
 
 const server = serve({
-  port: 8080,
-  fetch(req) {
-    const url = new URL(req.url);
+	port: 8080,
+	fetch(req) {
+		const url = new URL(req.url);
 
-    if (url.pathname === "/status") {
-      return new Response(JSON.stringify({
-        status: "healthy",
-        database: "connected",
-        worker: "ready"
-      }), {
-        headers: { "Content-Type": "application/json" }
-      });
-    }
+		if (url.pathname === "/status") {
+			return new Response(
+				JSON.stringify({
+					status: "healthy",
+					database: "connected",
+					worker: "ready",
+				}),
+				{
+					headers: { "Content-Type": "application/json" },
+				},
+			);
+		}
 
-    return new Response("API is running!");
-  },
+		return new Response("API is running!");
+	},
 });
 
 console.log(`API server running on port ${server.port}`);

--- a/examples/exec-probe/api.ts
+++ b/examples/exec-probe/api.ts
@@ -1,0 +1,24 @@
+// API service that depends on both database and worker
+
+import { serve } from "bun";
+
+const server = serve({
+  port: 8080,
+  fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/status") {
+      return new Response(JSON.stringify({
+        status: "healthy",
+        database: "connected",
+        worker: "ready"
+      }), {
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    return new Response("API is running!");
+  },
+});
+
+console.log(`API server running on port ${server.port}`);

--- a/examples/exec-probe/curse.toml
+++ b/examples/exec-probe/curse.toml
@@ -1,0 +1,25 @@
+# Example demonstrating exec readiness probes
+
+# Database service with exec readiness probe
+[[process]]
+name = "database"
+command = "bun run examples/exec-probe/mock-db.ts"
+readiness_probe = { type = "exec", command = "curl -f http://localhost:5432/health > /dev/null 2>&1" }
+
+# Web service that depends on database being ready
+[[process]]
+name = "web-server"
+command = "bun run examples/exec-probe/server.ts"
+deps = ["database"]
+
+# Background worker with file-based readiness check
+[[process]]
+name = "worker"
+command = "bun run examples/exec-probe/worker.ts"
+readiness_probe = { type = "exec", command = "test -f /tmp/worker-ready" }
+
+# API service that depends on both database and worker
+[[process]]
+name = "api"
+command = "bun run examples/exec-probe/api.ts"
+deps = ["database", "worker"]

--- a/examples/exec-probe/mock-db.ts
+++ b/examples/exec-probe/mock-db.ts
@@ -9,25 +9,25 @@ console.log("Initializing database schema and connections...");
 
 // Simulate database initialization taking 7 seconds
 setTimeout(() => {
-  isReady = true;
-  console.log("Database is now ready to accept connections!");
+	isReady = true;
+	console.log("Database is now ready to accept connections!");
 }, 7000);
 
 const server = serve({
-  port: 5432,
-  fetch(req) {
-    const url = new URL(req.url);
+	port: 5432,
+	fetch(req) {
+		const url = new URL(req.url);
 
-    if (url.pathname === "/health") {
-      if (isReady) {
-        return new Response("OK", { status: 200 });
-      } else {
-        return new Response("Database initializing...", { status: 503 });
-      }
-    }
+		if (url.pathname === "/health") {
+			if (isReady) {
+				return new Response("OK", { status: 200 });
+			} else {
+				return new Response("Database initializing...", { status: 503 });
+			}
+		}
 
-    return new Response("Database Mock", { status: 200 });
-  },
+		return new Response("Database Mock", { status: 200 });
+	},
 });
 
 console.log(`Mock database running on port ${server.port}`);

--- a/examples/exec-probe/mock-db.ts
+++ b/examples/exec-probe/mock-db.ts
@@ -1,0 +1,33 @@
+// Mock database service that serves a health endpoint
+
+import { serve } from "bun";
+
+let isReady = false;
+
+console.log("Database starting...");
+console.log("Initializing database schema and connections...");
+
+// Simulate database initialization taking 7 seconds
+setTimeout(() => {
+  isReady = true;
+  console.log("Database is now ready to accept connections!");
+}, 7000);
+
+const server = serve({
+  port: 5432,
+  fetch(req) {
+    const url = new URL(req.url);
+
+    if (url.pathname === "/health") {
+      if (isReady) {
+        return new Response("OK", { status: 200 });
+      } else {
+        return new Response("Database initializing...", { status: 503 });
+      }
+    }
+
+    return new Response("Database Mock", { status: 200 });
+  },
+});
+
+console.log(`Mock database running on port ${server.port}`);

--- a/examples/exec-probe/server.ts
+++ b/examples/exec-probe/server.ts
@@ -3,10 +3,10 @@
 import { serve } from "bun";
 
 const server = serve({
-  port: 3000,
-  fetch(req) {
-    return new Response("Web server is running!");
-  },
+	port: 3000,
+	fetch(req) {
+		return new Response("Web server is running!");
+	},
 });
 
 console.log(`Web server running on port ${server.port}`);

--- a/examples/exec-probe/server.ts
+++ b/examples/exec-probe/server.ts
@@ -1,0 +1,12 @@
+// Web server that depends on database
+
+import { serve } from "bun";
+
+const server = serve({
+  port: 3000,
+  fetch(req) {
+    return new Response("Web server is running!");
+  },
+});
+
+console.log(`Web server running on port ${server.port}`);

--- a/examples/exec-probe/worker.ts
+++ b/examples/exec-probe/worker.ts
@@ -1,0 +1,29 @@
+// Background worker that creates a file when ready
+
+import { writeFileSync } from "fs";
+
+console.log("Worker starting...");
+console.log("Performing initialization tasks...");
+
+// Simulate longer initialization work (10 seconds)
+setTimeout(() => {
+  console.log("Step 1/3: Loading configuration...");
+}, 2000);
+
+setTimeout(() => {
+  console.log("Step 2/3: Connecting to external services...");
+}, 5000);
+
+setTimeout(() => {
+  console.log("Step 3/3: Finalizing setup...");
+}, 8000);
+
+setTimeout(() => {
+  writeFileSync("/tmp/worker-ready", "ready");
+  console.log("Worker is ready! Created readiness file at /tmp/worker-ready");
+
+  // Keep the process running
+  setInterval(() => {
+    console.log("Worker processing...");
+  }, 5000);
+}, 10000); // 10 seconds before ready

--- a/examples/exec-probe/worker.ts
+++ b/examples/exec-probe/worker.ts
@@ -7,23 +7,23 @@ console.log("Performing initialization tasks...");
 
 // Simulate longer initialization work (10 seconds)
 setTimeout(() => {
-  console.log("Step 1/3: Loading configuration...");
+	console.log("Step 1/3: Loading configuration...");
 }, 2000);
 
 setTimeout(() => {
-  console.log("Step 2/3: Connecting to external services...");
+	console.log("Step 2/3: Connecting to external services...");
 }, 5000);
 
 setTimeout(() => {
-  console.log("Step 3/3: Finalizing setup...");
+	console.log("Step 3/3: Finalizing setup...");
 }, 8000);
 
 setTimeout(() => {
-  writeFileSync("/tmp/worker-ready", "ready");
-  console.log("Worker is ready! Created readiness file at /tmp/worker-ready");
+	writeFileSync("/tmp/worker-ready", "ready");
+	console.log("Worker is ready! Created readiness file at /tmp/worker-ready");
 
-  // Keep the process running
-  setInterval(() => {
-    console.log("Worker processing...");
-  }, 5000);
+	// Keep the process running
+	setInterval(() => {
+		console.log("Worker processing...");
+	}, 5000);
 }, 10000); // 10 seconds before ready

--- a/src/hooks/useProcessManager.tsx
+++ b/src/hooks/useProcessManager.tsx
@@ -121,7 +121,7 @@ function startReadinessTimer(
 				...(isReady ? { status: ProcessStatus.Running } : {}),
 			});
 		}
-	}, 500);
+	}, 1_000);
 
 	return timer;
 }

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -6,12 +6,15 @@ const CurseConfig = type({
 	process: type({
 		name: "string",
 		command: "string",
-		"readiness_probe?": {
+		"readiness_probe?": type({
 			type: "'http'",
 			host: "string",
 			path: "string",
 			port: "number",
-		},
+		}).or({
+			type: "'exec'",
+			command: "string",
+		}),
 		"deps?": "string[]",
 		"env?": "Record<string, string | number>",
 	}).array(),


### PR DESCRIPTION
## Summary

 Added support for exec readiness probes that execute shell
  commands and check exit codes.

  Changes:
  - Extended performReadinessProbe() in useProcessManager.tsx
  to handle exec type probes alongside existing http probes
  - Added comprehensive example in examples/exec-probe/
  demonstrating various exec probe patterns with realistic
  initialization delays

  Usage:
  readiness_probe = { type = "exec", command = "test -f
  /tmp/ready" }

  Process is considered ready when command exits with status
  code 0.