### PR TITLE
feat: use tick-based ui updates

### DIFF
--- a/src/hooks/useRenderTick.tsx
+++ b/src/hooks/useRenderTick.tsx
@@ -1,0 +1,13 @@
+import { useState, useEffect } from "react";
+
+export function useRenderTick(intervalMs: number = 1000) {
+	const [, forceUpdate] = useState(0);
+
+	useEffect(() => {
+		const interval = setInterval(() => {
+			forceUpdate((prev) => prev + 1);
+		}, intervalMs);
+
+		return () => clearInterval(interval);
+	}, [intervalMs]);
+}

--- a/src/ui/views/LogPage.tsx
+++ b/src/ui/views/LogPage.tsx
@@ -5,6 +5,7 @@ import stripAnsi from "strip-ansi";
 
 import { usePage, ViewPage } from "../../hooks/usePage";
 import { useProcessManager } from "../../hooks/useProcessManager";
+import { useRenderTick } from "../../hooks/useRenderTick";
 import { Colors } from "../../lib/Colors";
 import { preprocessLog } from "../../lib/LogProcessing";
 import {
@@ -29,7 +30,6 @@ function LogTable(props: {
 	onSelectModeChange?: (isSelectMode: boolean) => void;
 }) {
 	const { selectedProcess, killAllProcesses } = useProcessManager();
-	const [, forceUpdate] = useState(0);
 	const [autoScroll, setAutoScroll] = useState(true);
 	const [viewStartLine, setViewStartLine] = useState(0);
 	const [positionLost, setPositionLost] = useState(false);
@@ -52,6 +52,9 @@ function LogTable(props: {
 		onSearchCursorChange,
 		onSelectModeChange,
 	} = props;
+
+	// Force re-render every second to update logs and check position validity
+	useRenderTick();
 
 	// Function to highlight search terms in text
 	const highlightSearchTerm = (text: string, searchTerm: string) => {
@@ -76,15 +79,6 @@ function LogTable(props: {
 
 		return parts;
 	};
-
-	// Force re-render every second to update logs and check position validity
-	useEffect(() => {
-		const interval = setInterval(() => {
-			forceUpdate((prev) => prev + 1);
-		}, 1000);
-
-		return () => clearInterval(interval);
-	}, []);
 
 	// Handle view in context request
 	useEffect(() => {

--- a/src/ui/views/MainPage.tsx
+++ b/src/ui/views/MainPage.tsx
@@ -42,7 +42,8 @@ function getReadinessDisplay(process: Process): {
 }
 
 function ProcessTable() {
-	const { processes, selectedProcessIdx } = useProcessManager();
+	const { processesRef, selectedProcessIdx } = useProcessManager();
+	const processes = processesRef.current;
 	const [, forceUpdate] = useState(0);
 	const { stdout } = useStdout();
 
@@ -203,12 +204,13 @@ function ProcessTable() {
 
 export function MainPage() {
 	const {
-		processes,
+		processesRef,
 		setSelectedProcessIdx,
 		restartSelectedProcess,
 		killAllProcesses,
 		killSelectedProcess,
 	} = useProcessManager();
+	const processes = processesRef.current;
 
 	const { setPage } = usePage();
 	const [showShortcuts, setShowShortcuts] = useState(false);

--- a/src/ui/views/MainPage.tsx
+++ b/src/ui/views/MainPage.tsx
@@ -1,8 +1,13 @@
 import { Box, Text, useInput, useStdout } from "ink";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { usePage, ViewPage } from "../../hooks/usePage";
-import { useProcessManager, type Process, type ProcessType } from "../../hooks/useProcessManager";
+import {
+	useProcessManager,
+	type Process,
+	type ProcessType,
+} from "../../hooks/useProcessManager";
+import { useRenderTick } from "../../hooks/useRenderTick";
 import { Colors } from "../../lib/Colors";
 import {
 	ShortcutFooter,
@@ -44,7 +49,6 @@ function getReadinessDisplay(process: Process): {
 function ProcessTable() {
 	const { processesRef, selectedProcessIdx } = useProcessManager();
 	const processes = processesRef.current;
-	const [, forceUpdate] = useState(0);
 	const { stdout } = useStdout();
 
 	const terminalWidth = stdout?.columns ?? 80;
@@ -54,15 +58,6 @@ function ProcessTable() {
 		20,
 		terminalWidth - fixedColumnsWidth - borderAndPadding,
 	);
-
-	// Force re-render every second to update age display
-	useEffect(() => {
-		const interval = setInterval(() => {
-			forceUpdate((prev) => prev + 1);
-		}, 1000);
-
-		return () => clearInterval(interval);
-	}, []);
 
 	return (
 		<Box
@@ -215,6 +210,9 @@ export function MainPage() {
 	const { setPage } = usePage();
 	const [showShortcuts, setShowShortcuts] = useState(false);
 	const { stdout } = useStdout();
+
+	// Force re-render every second to update age display and logs
+	useRenderTick();
 
 	const shortcuts = [
 		"↑/↓ or j/k to navigate",


### PR DESCRIPTION
## Summary

Instead of using React state updates, we store process state in a ref and force re-render every second. This is actually more efficient in cases where there are a bunch of processes.