### PR TITLE
feat: update shutdown hook color

### DIFF
--- a/src/lib/Colors.ts
+++ b/src/lib/Colors.ts
@@ -1,6 +1,7 @@
 export const Colors = {
 	primary: "#8b5cf6", // violet
 	darkGray: "#4b5563",
+	mutedCyan: "#5f8a8b",
 	indigo: "#6366f1",
 	purple: "#a78bfa",
 	green: "#10b981",

--- a/src/ui/views/MainPage.tsx
+++ b/src/ui/views/MainPage.tsx
@@ -51,6 +51,7 @@ function ProcessTable() {
 	const { processesRef, selectedProcessIdx } = useProcessManager();
 	const processes = processesRef.current;
 	const { stdout } = useStdout();
+	const { status: programStatus } = useProgramState();
 
 	const terminalWidth = stdout?.columns ?? 80;
 	const fixedColumnsWidth = 10 + 2 + 8 + 2 + 8 + 2 + 8 + 2 + 8; // STATUS + margin + READY + margin + AGE + margin + MEM + margin + CPU
@@ -94,11 +95,17 @@ function ProcessTable() {
 			{processes.map((process: Process, index: number) => {
 				const isSelected = index === selectedProcessIdx;
 				const isSuccess = process.status === "success";
+				const isShutdownHookPending =
+					process.type === "shutdown_hook" &&
+					process.status === "pending" &&
+					programStatus === ProgramStatus.Running;
 				const textColor = isSelected
 					? "white"
 					: isSuccess
 						? Colors.darkGray
-						: Colors.indigo;
+						: isShutdownHookPending
+							? Colors.mutedCyan
+							: Colors.indigo;
 				return (
 					<Box
 						key={process.name}


### PR DESCRIPTION
## Summary

Adds some visual difference between pending shutdown hook and other pending processes.

<img width="1726" height="287" alt="Screenshot 2025-10-02 at 10 22 21 PM" src="https://github.com/user-attachments/assets/122dcfe0-8aa6-4d2a-b130-1ef8ec0e531c" />

